### PR TITLE
Make rate-limiter wrapper make use of go-lang rate-limiter instead of juju/ratelimit

### DIFF
--- a/fixchain/ratelimiter/limiter.go
+++ b/fixchain/ratelimiter/limiter.go
@@ -16,21 +16,25 @@
 package ratelimiter
 
 import (
-	"github.com/juju/ratelimit"
+   "context"
+   "golang.org/x/time/rate"
 )
 
 // Limiter is a simple rate limiter.
 type Limiter struct {
-	bucket *ratelimit.Bucket
+    ctx context.Context
+    bucket *rate.Limiter
 }
 
-// Wait blocks for the amount of time required by the Limiter so as to not
-// exceed its rate.
+// Wait blocks for the amount of time required by the Limiter to consume one token
+// so as to not exceed its rate.
 func (l *Limiter) Wait() {
-	l.bucket.Wait(1)
+	l.bucket.Wait(l.ctx)
 }
 
 // NewLimiter creates a new Limiter with a rate of limit per second.
 func NewLimiter(limit int) *Limiter {
-	return &Limiter{bucket: ratelimit.NewBucketWithRate(float64(limit), 1)}
+   return &Limiter{ctx: context.Background(),
+       bucket: rate.NewLimiter(rate.Limit(limit), 1)}
+
 }

--- a/fixchain/ratelimiter/limiter_test.go
+++ b/fixchain/ratelimiter/limiter_test.go
@@ -68,7 +68,11 @@ func TestRateLimiterGoroutines(t *testing.T) {
 			wg.Wait()
 			ds := float64(time.Since(start)) / float64(time.Second)
 			qps := float64(numOps) / ds
-			if qps > float64(limit)*1.01 {
+
+            // Allow a rate-margin of 0.05% to incorporate for algorithm differences in 
+            // https://pkg.go.dev/golang.org/x/time/rate.
+            // Value was choosen based on experimentation while testing.
+			if qps > float64(limit)*1.05 {
 				t.Errorf("#%d: Too many operations per second. Expected ~%d, got %f", i, limit, qps)
 			}
 		})

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.5
 	github.com/google/trillian v1.3.14-0.20210408144100-884ef511ce16
-	github.com/juju/ratelimit v1.0.1
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/prometheus/client_golang v1.10.0
@@ -21,6 +20,7 @@ require (
 	go.etcd.io/etcd/v3 v3.5.0-alpha.0
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	google.golang.org/genproto v0.0.0-20210331142528-b7513248f0ba
 	google.golang.org/grpc v1.36.1
 	google.golang.org/protobuf v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -411,8 +411,6 @@ github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/juju/ratelimit v1.0.1 h1:+7AIFJVQ0EQgq/K9+0Krm7m530Du7tIz0METWzN0RgY=
-github.com/juju/ratelimit v1.0.1/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
@@ -923,6 +921,8 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e h1:EHBhcS0mlXEAVwNyO2dLfjToGsyY4j24pTs2ScHnX7s=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba h1:O8mE0/t419eoIwhTFpKVkHiTs/Igowgfkj25AcZrtiE=
+golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
# Description
Make Ratelimiter wrapper make use of go-lang rate-limiter (https://pkg.go.dev/golang.org/x/time/rate)  instead of `juju/ratelimit` https://github.com/juju/ratelimit which is based on an LGPL-3 license.

# Test
See comments
 